### PR TITLE
Overlay view frame now adopts Floaty's superview bounds.

### DIFF
--- a/Sources/Floaty.swift
+++ b/Sources/Floaty.swift
@@ -542,11 +542,13 @@ open class Floaty: UIView {
 
     }
 	fileprivate func setOverlayFrame() {
-		overlayView.frame = CGRect(
-			x: 0,y: 0,
-			width: UIScreen.main.bounds.width,
-			height: UIScreen.main.bounds.height
-		)
+        if let superview = superview {
+		    overlayView.frame = CGRect(
+			  x: 0,y: 0,
+			  width: superview.bounds.width,
+			  height: superview.bounds.height
+		    )
+        }
 	}
 
     fileprivate func setShadow() {


### PR DESCRIPTION
This is useful when using the Floaty in a view controller on the iPad,
where you don't always want the overlay to cover the entire screen.

There is no change in behaviour when using FloatyManager.
Only affects Floaty view's added to a view manually.