### PR TITLE
issue #170: Floaty moves with keyboard only at first time, iOS 11

### DIFF
--- a/Sources/Floaty.swift
+++ b/Sources/Floaty.swift
@@ -849,7 +849,7 @@ open class Floaty: UIView {
     }
 
     @objc internal func keyboardWillShow(_ notification: Notification) {
-        guard let keyboardSize: CGFloat = (notification.userInfo?[UIKeyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue.size.height,
+        guard let keyboardSize: CGFloat = (notification.userInfo?[UIKeyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue.size.height,
             respondsToKeyboard, !sticky else {
                 return
         }


### PR DESCRIPTION
According to Apple Docs:

UIKeyboardFrameBeginUserInfoKey- The key for an NSValue object containing a CGRect that identifies the start frame of the keyboard in screen coordinates.
UIKeyboardFrameEndUserInfoKey - The key for an NSValue object containing a CGRect that identifies the end frame of the keyboard in screen coordinates.

https://developer.apple.com/documentation/uikit/uiwindow/keyboard_notification_user_info_keys