### PR TITLE
Change to meet basic Accessiblity guidelines 

### DIFF
--- a/Sources/Floaty.swift
+++ b/Sources/Floaty.swift
@@ -156,7 +156,11 @@ open class Floaty: UIView {
     /**
      
      */
-    @objc open var closed: Bool = true
+    @objc open var closed: Bool = true {
+        didSet {
+            accessibilityViewIsModal = !closed
+        }
+    }
     
     /**
      Whether or not floaty responds to keyboard notifications and adjusts its position accordingly
@@ -220,6 +224,11 @@ open class Floaty: UIView {
      */
     fileprivate var isCustomFrame: Bool = false
     
+    /**
+     An accessibility button for the main Fab Button
+     */
+    fileprivate var accessibilityView : UIView = UIView()
+    
     // MARK: - Initialize
     
     /**
@@ -229,6 +238,7 @@ open class Floaty: UIView {
         super.init(frame: CGRect(x: 0, y: 0, width: size, height: size))
         backgroundColor = UIColor.clear
         setObserver()
+        setAccessibilityView()
     }
     
     /**
@@ -239,6 +249,7 @@ open class Floaty: UIView {
         super.init(frame: CGRect(x: 0, y: 0, width: size, height: size))
         backgroundColor = UIColor.clear
         setObserver()
+        setAccessibilityView()
     }
     
     /**
@@ -250,6 +261,7 @@ open class Floaty: UIView {
         backgroundColor = UIColor.clear
         isCustomFrame = true
         setObserver()
+        setAccessibilityView()
     }
     
     /**
@@ -262,6 +274,7 @@ open class Floaty: UIView {
         clipsToBounds = false
         isCustomFrame = true
         setObserver()
+        setAccessibilityView()
     }
     
     // MARK: - Method
@@ -331,6 +344,8 @@ open class Floaty: UIView {
             case .none:
                 noneAnimationWithOpen()
             }
+            
+            UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, items.first);
         }
         
         animationGroup.notify(queue: .main) {
@@ -379,6 +394,7 @@ open class Floaty: UIView {
             case .none:
                 noneAnimationWithClose()
             }
+            UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, self);
         }
         
         animationGroup.notify(queue: .main) {
@@ -1157,3 +1173,63 @@ extension UIView {
     }
 }
 
+
+// MARK: - Accessibility Handling
+extension Floaty {
+    
+    func setAccessibilityView() {
+        self.addSubview(accessibilityView)
+        accessibilityView.isAccessibilityElement = true
+        accessibilityView.accessibilityTraits |= UIAccessibilityTraitButton
+        if #available(iOS 9.0, *) {
+            accessibilityView.translatesAutoresizingMaskIntoConstraints = false;
+            accessibilityView.topAnchor.constraint(equalTo: self.topAnchor).isActive = true
+            accessibilityView.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
+            accessibilityView.leftAnchor.constraint(equalTo: self.leftAnchor).isActive = true
+            accessibilityView.rightAnchor.constraint(equalTo: self.rightAnchor).isActive = true
+        } else {
+            // Fallback on earlier versions
+            accessibilityView.frame = self.frame
+        }
+    }
+    
+    open override var accessibilityLabel : String? {
+        get {
+            return accessibilityView.accessibilityLabel
+        }
+        set(newLabel) {
+            accessibilityView.accessibilityLabel = newLabel
+        }
+    }
+    
+    open override var accessibilityHint : String? {
+        get {
+            return accessibilityView.accessibilityHint
+        }
+        set(newHint) {
+            accessibilityView.accessibilityHint = newHint
+        }
+    }
+    
+    open override var accessibilityValue : String? {
+        get {
+            return accessibilityView.accessibilityValue
+        }
+        set(newHint) {
+            accessibilityView.accessibilityValue = newHint
+        }
+    }
+    
+    open override var accessibilityElements: [Any]? {
+        get {
+            if (closed) {
+                return [accessibilityView]
+            } else {
+                return [accessibilityView] + items
+            }
+        }
+        set {
+            
+        }
+    }
+}

--- a/Sources/Floaty.swift
+++ b/Sources/Floaty.swift
@@ -1176,21 +1176,15 @@ extension UIView {
 
 // MARK: - Accessibility Handling
 extension Floaty {
+    open override func layoutSubviews() {
+        super.layoutSubviews();
+        accessibilityView.frame = CGRect(x: 0, y: 0, width: size, height: size)
+    }
     
     func setAccessibilityView() {
         self.addSubview(accessibilityView)
         accessibilityView.isAccessibilityElement = true
         accessibilityView.accessibilityTraits |= UIAccessibilityTraitButton
-        if #available(iOS 9.0, *) {
-            accessibilityView.translatesAutoresizingMaskIntoConstraints = false;
-            accessibilityView.topAnchor.constraint(equalTo: self.topAnchor).isActive = true
-            accessibilityView.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
-            accessibilityView.leftAnchor.constraint(equalTo: self.leftAnchor).isActive = true
-            accessibilityView.rightAnchor.constraint(equalTo: self.rightAnchor).isActive = true
-        } else {
-            // Fallback on earlier versions
-            accessibilityView.frame = self.frame
-        }
     }
     
     open override var accessibilityLabel : String? {
@@ -1233,3 +1227,4 @@ extension Floaty {
         }
     }
 }
+


### PR DESCRIPTION
Changes made to meet WCAG A guidelines for Accessibility #182 

This change creates a transparent view with accessible values to it to exist along with the FloatyItems.  Added are passthrough methods for accessibilityLabel, accessibilityHint and accessibilityValue.

Ideally, accessibilityValue would be along the lines of "Opened" and "Closed", however translated versions of that text is pretty much out of scope for this. 

FloatyItems with a title are basically accessible. (They do not have the button state added to the titleLabel, however, I'd rather feedback on how much extra work a user would need to make it more properly accessible.

Current code I use to make the items properly accessible: 
```
//FloatyItem with only an image needs all its accessible element set
let item = floaty.addItem(icon: UIImage.init(named: "placeholder_1"))
item.isAccessibilityElement = true
item.accessibilityLabel = "Log Workout"
item.accessibilityTraits |= UIAccessibilityTraitButton

//FloatyItem with a title, as a UILabel is naturally accessible, only need to add the button trait to it, it will read the label.
let item2 = floaty.addItem("Log Nutrition", icon: UIImage.init(named: "placeholder_2"))
item2.titleLabel.accessibilityTraits |= UIAccessibilityTraitButton
```



