### PR TITLE
Fixing .slideDown open type

### DIFF
--- a/Sources/Floaty.swift
+++ b/Sources/Floaty.swift
@@ -1091,6 +1091,11 @@ extension Floaty {
      */
     fileprivate func slideDownAnimationWithOpen(group: DispatchGroup) {
         var itemHeight: CGFloat = 0
+        
+        if self.size > self.itemSize {
+            itemHeight = self.size - self.itemSize
+        }
+        
         for item in items {
             if item.isHidden == true { continue }
             if verticalDirection == .up {

--- a/Sources/Floaty.swift
+++ b/Sources/Floaty.swift
@@ -1092,7 +1092,7 @@ extension Floaty {
     fileprivate func slideDownAnimationWithOpen(group: DispatchGroup) {
         var itemHeight: CGFloat = 0
         
-        if self.size > self.itemSize {
+        if self.size > self.itemSize && verticalDirection == .down {
             itemHeight = self.size - self.itemSize
         }
         


### PR DESCRIPTION
When Floaty button is bigger than its items and .slideDown animation is used first item overlaps the Floaty button. This is because items views are top aligned with the Floaty button.

![screen shot 2018-03-15 at 10 27 10 am](https://user-images.githubusercontent.com/5511034/37455357-8c7d0e4a-2845-11e8-9acd-7cae69036437.png)
