### PR TITLE
Making Floaty open/close functions accessible for override

### DIFF
--- a/Sources/Floaty.swift
+++ b/Sources/Floaty.swift
@@ -312,7 +312,7 @@ open class Floaty: UIView {
   /**
    Items open.
    */
-  @objc public func open() {
+  @objc open func open() {
     fabDelegate?.floatyWillOpen?(self)
     let animationGroup = DispatchGroup()
     
@@ -365,7 +365,7 @@ open class Floaty: UIView {
   /**
    Items close.
    */
-  @objc public func close() {
+  @objc open func close() {
     fabDelegate?.floatyWillClose?(self)
     let animationGroup = DispatchGroup()
     


### PR DESCRIPTION
As a part of the changes to support Swift 4.2 the open and close functions found inside the Floaty class were switched from being scoped as open to being scoped as public. This breaks any implementations where a developer may have chosen to sub-class the Floaty implementation and override these methods. A potential use case being the one mentioned in [#234](https://github.com/kciter/Floaty/issues/234) where a developer may wish to call the handler of the FloatyItem when only one FloatyItem is present rather than showing that single item and requiring the user to tap it. 

```
import Floaty
class CustomFloaty: Floaty {
  override fun open() {
    if self.items.count == 1 {
      let item = self.items[0]
      item.handler?(item)
    } else {
      super.open()
    }
  }
}
```

This is my first pull request so I apologize if I am overstepping or going about this the wrong way. I'd like to say thank the maintainers of this library, it has been very useful!