### PR TITLE
Fix Safe Area insets

### DIFF
--- a/Sources/Floaty.swift
+++ b/Sources/Floaty.swift
@@ -63,6 +63,12 @@ open class Floaty: UIView {
    */
   @IBInspectable
   @objc open var autoCloseOnTap: Bool = true
+    
+  /**
+   Places button relative to the Safe Area
+   */
+  @IBInspectable
+  @objc open var relativeToSafeArea: Bool = true
   
   /**
    Degrees to rotate image
@@ -759,7 +765,8 @@ open class Floaty: UIView {
     
     var horizontalMargin = size;
     var verticalMargin = size + keyboardSize;
-    if #available(iOS 11, *) {
+    
+    if #available(iOS 11, *), relativeToSafeArea, let safeAreaInsets = UIApplication.shared.delegate?.window??.safeAreaInsets {
       horizontalMargin += safeAreaInsets.right
       verticalMargin += safeAreaInsets.bottom
     }


### PR DESCRIPTION
There is a bug with show/hide keyboard. You can reproduce it in demo project. Open the app, button is relative to Safe Area. Tap in textfield, then tap outside of keyboard. Button is not relative to safe area, because safeAreaInsets.bottom is 0 at that moment.

Also, I have added relativeToSafeArea property for those cases, when it is not required to place button relative to safe area.