### PR TITLE
Floaty shouldOpen/shouldClose handlers and bool to handle first item directly

### DIFF
--- a/Floaty.xcodeproj/project.pbxproj
+++ b/Floaty.xcodeproj/project.pbxproj
@@ -47,7 +47,9 @@
 				B65A2E551D5975130045483D /* Floaty */,
 				B65A2E541D5975130045483D /* Products */,
 			);
+			indentWidth = 2;
 			sourceTree = "<group>";
+			tabWidth = 2;
 		};
 		B65A2E541D5975130045483D /* Products */ = {
 			isa = PBXGroup;

--- a/Sources/Floaty.swift
+++ b/Sources/Floaty.swift
@@ -63,6 +63,12 @@ open class Floaty: UIView {
    */
   @IBInspectable
   @objc open var autoCloseOnTap: Bool = true
+
+  /**
+   Runs first item handler directly on tap (without opening menu)
+   */
+  @IBInspectable
+  @objc open var handleFirstItemDirectly: Bool = false
     
   /**
    Places button relative to the Safe Area
@@ -339,6 +345,11 @@ open class Floaty: UIView {
    Items open.
    */
   @objc open func open() {
+    if handleFirstItemDirectly, let item = items.first, let handler = item.handler {
+      handler(item)
+      return
+    }
+
     if let shouldOpen = fabDelegate?.floatyShouldOpen?(self), shouldOpen == false {
       return
     }

--- a/Sources/Floaty.swift
+++ b/Sources/Floaty.swift
@@ -339,6 +339,10 @@ open class Floaty: UIView {
    Items open.
    */
   @objc open func open() {
+    if let shouldOpen = fabDelegate?.floatyShouldOpen?(self), shouldOpen == false {
+      return
+    }
+
     fabDelegate?.floatyWillOpen?(self)
     let animationGroup = DispatchGroup()
     
@@ -395,6 +399,10 @@ open class Floaty: UIView {
    Items close.
    */
   @objc open func close() {
+    if let shouldClose = fabDelegate?.floatyShouldClose?(self), shouldClose == false {
+      return
+    }
+
     fabDelegate?.floatyWillClose?(self)
     let animationGroup = DispatchGroup()
     

--- a/Sources/FloatyDelegate.swift
+++ b/Sources/FloatyDelegate.swift
@@ -18,10 +18,14 @@ import Foundation
    - parameter floaty: The FAB widget that was selected by the user.
    */
   @objc optional func emptyFloatySelected(_ floaty: Floaty)
+
+  @objc optional func floatyShouldOpen(_ floaty: Floaty) -> Bool
   
   @objc optional func floatyWillOpen(_ floaty: Floaty)
   
   @objc optional func floatyDidOpen(_ floaty: Floaty)
+
+  @objc optional func floatyShouldClose(_ floaty: Floaty) -> Bool
   
   @objc optional func floatyWillClose(_ floaty: Floaty)
   


### PR DESCRIPTION
This PR adds two items:

### 1. Added delegate methods `floatyShouldOpen` and `floatyShouldOpen`.
Can be used for FABs with one item which should be directly opened, instead of opening a menu. For example:
```
import Floaty

class ViewController: UIViewController {
  // ...

  func setupFloaty() {
    let floaty = Floaty()
    floaty.fabDelegate = self
    floaty.addItem("Add", icon: nil) { item in
      // Do something
    }
    view.addSubview(floaty)
  }
}

extension ViewController: FloatyDelegate {
  func floatyShouldOpen(_ floaty: Floaty) -> Bool {
    guard floaty.items.count == 1, let item = floaty.items.first, let handler = item.handler
      else { return true }

    handler(item)
    return false
  }
}
```

### 2. Added boolean to handle the first item directly, without opening the menu.
Can be used for the same goal as 1, without the need of implementing a delegate method. For example:
```
import Floaty

class ViewController: UIViewController {
  // ...

  func setupFloaty() {
    let floaty = Floaty()
    floaty.handleFirstItemDirectly = true
    floaty.addItem("Add", icon: nil) {  item in
        // Do something
    }
    view.addSubview(floaty)
  }
}
```

This PR fixes https://github.com/kciter/Floaty/issues/198, fixes https://github.com/kciter/Floaty/issues/105, fixes https://github.com/kciter/Floaty/issues/234 and possibly https://github.com/kciter/Floaty/issues/179.