### PR TITLE
Partial horizontal support and prevent close on overlay tap option

### DIFF
--- a/Sources/Floaty.swift
+++ b/Sources/Floaty.swift
@@ -65,6 +65,12 @@ open class Floaty: UIView {
   @objc open var autoCloseOnTap: Bool = true
 
   /**
+   Automatically closes when tappen on overlay
+   */
+  @IBInspectable
+  @objc open var autoCloseOnOverlayTap: Bool = true
+
+  /**
    Runs first item handler directly on tap (without opening menu)
    */
   @IBInspectable
@@ -362,8 +368,12 @@ open class Floaty: UIView {
       setOverlayView()
       self.superview?.insertSubview(overlayView, aboveSubview: self)
       self.superview?.bringSubviewToFront(self)
-      overlayView.addTarget(self, action: #selector(close), for: UIControl.Event.touchUpInside)
-      
+      if autoCloseOnOverlayTap {
+        overlayView.addTarget(self, action: #selector(close), for: UIControl.Event.touchUpInside)
+      } else {
+        overlayView.isUserInteractionEnabled = false
+      }
+
       overlayViewDidCompleteOpenAnimation = false
       animationGroup.enter()
       UIView.animate(withDuration: 0.3, delay: 0,

--- a/Sources/FloatyDelegate.swift
+++ b/Sources/FloatyDelegate.swift
@@ -30,7 +30,9 @@ import Foundation
   @objc optional func floatyWillClose(_ floaty: Floaty)
   
   @objc optional func floatyDidClose(_ floaty: Floaty)
-  
+
+  @objc optional func shallWorkHorizontal() -> Bool
+
   /**
    This method has been deprecated. Use floatyWillOpen and floatyDidOpen instead.
    */


### PR DESCRIPTION
Implemented horizontal support for one of the animations. The rest can be implemented easily by the ones who want to support.

Added support for disabling close by tapping on overlay. Used for popover tables. When tapped they were closing the floaty first.