### PR TITLE
Fix: Limit the scope of operator

### DIFF
--- a/Sources/FloatyItem.swift
+++ b/Sources/FloatyItem.swift
@@ -286,6 +286,8 @@ open class FloatyItem: UIView {
   }
 }
 
-func + (left: CGPoint, right: CGPoint) -> CGPoint {
-  return CGPoint(x: left.x + right.x, y: left.y + right.y)
+private extension CGPoint {
+    static func + (left: CGPoint, right: CGPoint) -> CGPoint {
+        return CGPoint(x: left.x + right.x, y: left.y + right.y)
+    }
 }


### PR DESCRIPTION
According to https://github.com/realm/SwiftLint/issues/2395, it is better not to declare it as a free function.

This is spotted by linter rules and I'd like to propose this fix to make the code taste better. 😄 