### PR TITLE
Update Floaty.podspec

### DIFF
--- a/Floaty.podspec
+++ b/Floaty.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/kciter/Floaty.git", :tag => "#{s.version}" }
   s.platform     = :ios, '10.0'
   s.source_files = 'Sources/*.{swift}'
+  s.swift_version = '5.0'
   s.frameworks   = 'UIKit', 'Foundation'
   s.requires_arc = true
 end


### PR DESCRIPTION
Cocoapods-Rome requires SWIFT_VERSION in order to build the framework

otherwise it will raise error like this

```
[!] Unable to determine Swift version for the following pods:

- `Floaty` does not specify a Swift version and none of the targets (`App`) integrating it have the `SWIFT_VERSION` attribute set. Please contact the author or set the `SWIFT_VERSION` attribute in at least one of the targets that integrate this pod.
```