### PR TITLE
Fix crash issue on iPad for macOS and macCatalyst

### DIFF
--- a/Sources/Floaty.swift
+++ b/Sources/Floaty.swift
@@ -142,6 +142,7 @@ open class Floaty: UIView {
   @objc @IBInspectable
   open var buttonImage: UIImage? = nil {
     didSet {
+      self.buttonImageView = UIImageView(image: buttonImage)
       self.setNeedsDisplay()
     }
   }
@@ -767,7 +768,6 @@ open class Floaty: UIView {
 
   fileprivate func setButtonImage() {
     buttonImageView.removeFromSuperview()
-    buttonImageView = UIImageView(image: buttonImage)
     buttonImageView.tintColor = plusColor
     let currentTransform = buttonImageView.transform
     buttonImageView.transform = .identity


### PR DESCRIPTION
The TAB keep crash due to the `buttonImageView = UIImageView(image: buttonImage)` trigger `draw(_:)` so the app running in the infinite loop on the macOS.

Bring the `buttonImageView` reset code before `setNeedsDisplay` fix it. And iOS/iPadOS and macOS all works