### PR TITLE
Changing class docs to remove references of old naming

### DIFF
--- a/Sources/Floaty.h
+++ b/Sources/Floaty.h
@@ -7,10 +7,10 @@
 
 #import <UIKit/UIKit.h>
 
-//! Project version number for KCFloatingActionButton.
+//! Project version number for Floaty.
 FOUNDATION_EXPORT double FloatyVersionNumber;
 
-//! Project version string for KCFloatingActionButton.
+//! Project version string for Floaty.
 FOUNDATION_EXPORT const unsigned char FloatyVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <Floaty/PublicHeader.h>

--- a/Sources/FloatyManager.swift
+++ b/Sources/FloatyManager.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 /**
- KCFloatingActionButton dependent on UIWindow.
+ Floaty dependent on UIWindow.
  */
 open class FloatyManager: NSObject {
   private static var __once: () = {

--- a/Sources/FloatyViewController.swift
+++ b/Sources/FloatyViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 /**
- KCFloatingActionButton dependent on UIWindow.
+ Floaty dependent on UIWindow.
  */
 open class FloatyViewController: UIViewController {
   public let floaty = Floaty()

--- a/Sources/FloatyWindow.swift
+++ b/Sources/FloatyWindow.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 /**
- KCFloatingActionButton dependent on UIWindow.
+ Floaty dependent on UIWindow.
  */
 class FloatyWindow: UIWindow {
   override init(frame: CGRect) {


### PR DESCRIPTION
I found some old references to `KCFloatingActionButton` naming on class docs so I changed them to the new `Floaty` naming.